### PR TITLE
6g missing, fixes for go 1.6

### DIFF
--- a/dwarf/frame_test.go
+++ b/dwarf/frame_test.go
@@ -48,7 +48,7 @@ func doPCToSPTest(self bool) bool {
 	}
 	// This command builds pcsptest from testdata/pcsptest.go.
 	pcsptestBinary = filepath.Join(pcspTempDir, "pcsptest")
-	command := fmt.Sprintf("go tool 6g -o %s.6 testdata/pcsptest.go && go tool 6l -H %s -o %s %s.6",
+	command := fmt.Sprintf("go tool compile -o %s.6 testdata/pcsptest.go && go tool link -H %s -o %s %s.6",
 		pcsptestBinary, runtime.GOOS, pcsptestBinary, pcsptestBinary)
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = os.Stdout

--- a/dwarf/pclntab_test.go
+++ b/dwarf/pclntab_test.go
@@ -56,7 +56,7 @@ func dotest(self bool) bool {
 	// the resulting binary looks like it was built from pclinetest.s,
 	// but we have renamed it to keep it away from the go tool.
 	pclinetestBinary = filepath.Join(pclineTempDir, "pclinetest")
-	command := fmt.Sprintf("go tool 6a -o %s.6 ../../gosym/pclinetest.asm && go tool 6l -H %s -E main -o %s %s.6",
+	command := fmt.Sprintf("go tool asm -o %s.6 ../gosym/pclinetest.asm && go tool link -H %s -E main -o %s %s.6",
 		pclinetestBinary, runtime.GOOS, pclinetestBinary, pclinetestBinary)
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = os.Stdout

--- a/server/server.go
+++ b/server/server.go
@@ -442,9 +442,8 @@ func (s *Server) handleBreakpointAtLine(req *protocol.BreakpointAtLineRequest, r
 	}
 	if pcs, err := s.dwarfData.LineToPCs(req.File, req.Line); err != nil {
 		return err
-	} else {
-		return s.addBreakpoints(pcs, resp)
 	}
+	return s.addBreakpoints(pcs, resp)
 }
 
 // addBreakpoints adds breakpoints at the addresses in pcs, then stores pcs in the response.
@@ -699,18 +698,18 @@ func (s *Server) parseParameterOrLocal(entry *dwarf.Entry, fp uint64) (debug.Loc
 	v.Name, _ = entry.Val(dwarf.AttrName).(string)
 	if off, err := s.dwarfData.EntryTypeOffset(entry); err != nil {
 		return v, err
-	} else {
-		v.Var.TypeID = uint64(off)
 	}
+	v.Var.TypeID = uint64(off)
+
 	if i := entry.Val(dwarf.AttrLocation); i == nil {
 		return v, fmt.Errorf("missing location description")
 	} else if locationDescription, ok := i.([]uint8); !ok {
 		return v, fmt.Errorf("unsupported location description")
 	} else if offset, err := evalLocation(locationDescription); err != nil {
 		return v, err
-	} else {
-		v.Var.Address = fp + uint64(offset)
 	}
+	v.Var.Address = fp + uint64(offset)
+
 	return v, nil
 }
 


### PR DESCRIPTION
makes `go test ./dwarf/...` not complain about "go tool 6g" etc, since they have been renamed.
6g => compile
6l => link
6a => asm

after this change, this test now fails. i am not sure what would be correct way to fix:
````
--- FAIL: TestPCToLine (0.18s)
	pclntab_test.go:132: got 2; want 13
```

finally, there is an issue preventing the full test suite to be run
```at line 54, file server/server.go
undefined: syscall.PtraceRegs```

i looked into it a bit but cant find any issue with the code.