### PR TITLE
Workaround for `panic: weird mapping Exec`

### DIFF
--- a/internal/gocore/process.go
+++ b/internal/gocore/process.go
@@ -287,7 +287,7 @@ func (p *Process) readSpans(mheap region, arenas []arena) {
 		switch m.Perm() {
 		case core.Read:
 			readOnly += size
-		case core.Read | core.Exec:
+		case core.Read | core.Exec, core.Exec:
 			text += size
 		case core.Read | core.Write:
 			if m.CopyOnWrite() {


### PR DESCRIPTION
Workaround for errors like:
```
panic: weird mapping Exec

goroutine 1 [running]:
golang.org/x/debug/internal/gocore.(*Process).readSpans(0xc0003322c0, 0xc0003322c0, 0xa58f780, 0xc00e328d20, 0xc00fa6c000, 0x4b, 0x80)
	/home/bozaro/github/debug/internal/gocore/process.go:316 +0x304e
golang.org/x/debug/internal/gocore.(*Process).readHeap(0xc0003322c0)
	/home/bozaro/github/debug/internal/gocore/process.go:272 +0x77b
golang.org/x/debug/internal/gocore.Core(0xc00016e000, 0x40, 0x0, 0x0)
	/home/bozaro/github/debug/internal/gocore/process.go:157 +0x2c4
main.readCore(0xc000167d50, 0xc000167ce0, 0x783174, 0xc00011edc0)
	/home/bozaro/github/debug/cmd/viewcore/main.go:265 +0xd2
main.runRead(0xc51f60, 0xc000064de0, 0x1, 0x1)
	/home/bozaro/github/debug/cmd/viewcore/main.go:719 +0x34
github.com/spf13/cobra.(*Command).execute(0xc51f60, 0xc000064da0, 0x1, 0x1, 0xc51f60, 0xc000064da0)
	/home/bozaro/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:766 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0xc507a0, 0x8c0862, 0x1, 0xc000167f00)
	/home/bozaro/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852 +0x2ea
github.com/spf13/cobra.(*Command).Execute(...)
	/home/bozaro/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
main.main()
	/home/bozaro/github/debug/cmd/viewcore/main.go:243 +0x104
```

Dump was generated by binary compiled with Go 1.13.9.