### PR TITLE
internal/gocore: extract type name of method value from its wrapper function name

### DIFF
--- a/internal/gocore/type.go
+++ b/internal/gocore/type.go
@@ -527,7 +527,7 @@ func (fr *frameReader) ReadInt(a core.Address) int64 {
 }
 
 // Match struct method. eg. main.(*Bar).func
-var methodRegexp = regexp.MustCompile(`([\w]+)\.\((\*[\w]+)\)\.[\w-]+$`)
+var methodRegexp = regexp.MustCompile(`([\w]+)\.\(\*([\w]+)\)\.[\w-]+$`)
 
 // typeObject takes an address and a type for the data at that address.
 // For each pointer it finds in the memory at that address, it calls add with the pointer
@@ -622,7 +622,7 @@ func (p *Process) typeObject(a core.Address, t *Type, r reader, add func(core.Ad
 		// handle the special case for struct method.
 		// the closure argument must be the struct/pointer, when the closure function is a method of the struct.
 		if matches := methodRegexp.FindStringSubmatch(f.name); len(matches) == 3 {
-			typeName := matches[1] + "." + matches[2]
+			typeName := "*" + matches[1] + "." + matches[2]
 			s := p.runtimeNameMap[typeName]
 			if len(s) > 0 {
 				typ := s[0]

--- a/internal/gocore/type.go
+++ b/internal/gocore/type.go
@@ -526,8 +526,28 @@ func (fr *frameReader) ReadInt(a core.Address) int64 {
 	return fr.p.proc.ReadInt(a)
 }
 
-// Match struct method. eg. main.(*Bar).func
-var methodRegexp = regexp.MustCompile(`([\w]+)\.\(\*([\w]+)\)\.[\w-]+$`)
+// Match wrapper function name for method value.
+// eg. main.(*Bar).func-fm, or main.Bar.func-fm.
+var methodRegexp = regexp.MustCompile(`(\w+)\.(\(\*)?(\w+)(\))?\.\w+\-fm$`)
+
+// Extract the type of the method value from its wrapper function name,
+// return the type named *main.Bar or main.Bar, in the previous cases.
+func extractTypeFromFunctionName(method string, p *Process) *Type {
+	if matches := methodRegexp.FindStringSubmatch(method); len(matches) == 5 {
+		var typeName string
+		if matches[2] == "(*" && matches[4] == ")" {
+			typeName = "*" + matches[1] + "." + matches[3]
+		} else {
+			typeName = matches[1] + "." + matches[3]
+		}
+		s := p.runtimeNameMap[typeName]
+		if len(s) > 0 {
+			// TODO: filter with the object size when there are multiple candidates.
+			return s[0]
+		}
+	}
+	return nil
+}
 
 // typeObject takes an address and a type for the data at that address.
 // For each pointer it finds in the memory at that address, it calls add with the pointer
@@ -619,16 +639,11 @@ func (p *Process) typeObject(a core.Address, t *Type, r reader, add func(core.Ad
 			f.closure = ft
 		}
 		p.typeObject(closure, ft, r, add)
-		// handle the special case for struct method.
-		// the closure argument must be the struct/pointer, when the closure function is a method of the struct.
-		if matches := methodRegexp.FindStringSubmatch(f.name); len(matches) == 3 {
-			typeName := "*" + matches[1] + "." + matches[2]
-			s := p.runtimeNameMap[typeName]
-			if len(s) > 0 {
-				typ := s[0]
-				ptr := closure.Add(p.proc.PtrSize())
-				p.typeObject(ptr, typ, r, add)
-			}
+		// handle the special case for method value.
+		// It's a single-entry closure laid out like {pc uintptr, x T}.
+		if typ := extractTypeFromFunctionName(f.name, p); typ != nil {
+			ptr := closure.Add(p.proc.PtrSize())
+			p.typeObject(ptr, typ, r, add)
 		}
 	case KindArray:
 		n := t.Elem.Size


### PR DESCRIPTION
It's a single-entry closure laid out like `{pc uintptr, x T}`, and the target pc is for wrapper functions named like pkg.T.m-fm or pkg.(*T).m-fm.
So, extract the type name pkg.T or *pkg.T from its wrapper function name.