### PR TITLE
Add nil checks for type values when processing objects

### DIFF
--- a/internal/gocore/type.go
+++ b/internal/gocore/type.go
@@ -193,6 +193,9 @@ func (p *Process) findItab() runtimeItab {
 
 // Type is the field representing either abi.ITab.Type or runtime.itab._type.
 func (r runtimeItab) Type() *Field {
+	if r.typ == nil {
+		return nil
+	}
 	return r.typ.field("Type")
 }
 
@@ -642,6 +645,9 @@ func (p *Process) typeObject(a core.Address, t *Type, r reader, add func(core.Ad
 			return
 		}
 		if t.Kind == KindIface {
+			if p.findItab().Type() == nil {
+				return
+			}
 			typPtr = p.proc.ReadPtr(typPtr.Add(p.findItab().Type().Off))
 		}
 		// TODO: for KindEface, type typPtr. It might point to the heap


### PR DESCRIPTION
Ran into the below two nil-ptr exceptions.

Culprit seemed to be due to parsing a `runtime.itabTableType` resource:

```
     2  40960  81920 [1+8?]runtime.itabTableType
```

Added two nil-ptr checks to skip if a nil type is encountered.

```
Core "tmp/core.283046" was generated by "/gce-pd-csi-driver"
Entering interactive mode (type 'help' for commands)
(viewcore) histogram
Error while trying to run command "histogram": runtime error: invalid memory address or nil pointer dereference
Stack: goroutine 1 [running]:
runtime/debug.Stack()
        /usr/lib/google-golang/src/runtime/debug/stack.go:26 +0x5e
main.capturePanic.func1()
        /workspace/debug/cmd/viewcore/main.go:372 +0x3d
panic({0x9e8b20?, 0xecb700?})
        /usr/lib/google-golang/src/runtime/panic.go:799 +0x132
golang.org/x/debug/internal/gocore.(*Type).field(...)
        /workspace/debug/internal/gocore/type.go:86
golang.org/x/debug/internal/gocore.runtimeItab.Type(...)
        /workspace/debug/internal/gocore/type.go:196
golang.org/x/debug/internal/gocore.(*Process).typeObject(0xc000280000, 0x300b8f0, 0xc001f242a0, {0xb348b0, 0xc000274000}, 0xc00b1e3280)
        /workspace/debug/internal/gocore/type.go:645 +0x155
golang.org/x/debug/internal/gocore.(*Process).doTypeHeap.func2(0x0?)
        /workspace/debug/internal/gocore/type.go:536 +0x91
golang.org/x/debug/internal/gocore.(*Process).ForEachRoot(...)
        /workspace/debug/internal/gocore/object.go:191
golang.org/x/debug/internal/gocore.(*Process).doTypeHeap(0xc000280000)
        /workspace/debug/internal/gocore/type.go:529 +0x1f6
sync.(*Once).doSlow(0x564562?, 0xc00b1e3560?)
        /usr/lib/google-golang/src/sync/once.go:78 +0xab
sync.(*Once).Do(...)
        /usr/lib/google-golang/src/sync/once.go:69
golang.org/x/debug/internal/gocore.(*Process).typeHeap(...)
        /workspace/debug/internal/gocore/type.go:400
golang.org/x/debug/internal/gocore.(*Process).Type(0xc000280000, 0xc000034000)
        /workspace/debug/internal/gocore/object.go:219 +0x4a
main.typeName(0xc000280000, 0xc000034000)
        /workspace/debug/cmd/viewcore/main.go:789 +0x9e
main.runHistogram.func1(0xc000280000?, 0xc000034000, 0x8?)
        /workspace/debug/cmd/viewcore/main.go:484 +0x3a
golang.org/x/debug/internal/gocore.(*Process).ForEachRootPtr.func1(0x0, 0xc00b35afc0?)
        /workspace/debug/internal/gocore/object.go:257 +0x3f
golang.org/x/debug/internal/gocore.walkRootTypePtrs(0xc000280000, 0xc002b15bc0, {0xc00b1e3718, 0x8, 0x8}, 0x0, 0xc007c4c360?, 0xc00b1e3720)
        /workspace/debug/internal/gocore/root.go:163 +0x2ab
golang.org/x/debug/internal/gocore.(*Process).forEachRootPtr(...)
        /workspace/debug/internal/gocore/object.go:269
golang.org/x/debug/internal/gocore.(*Process).ForEachRootPtr(0xc0000fa300?, 0xa6acf5?, 0x3?)
        /workspace/debug/internal/gocore/object.go:254 +0x4b
main.runHistogram(0xc0000fa300?, {0xeffd80?, 0x4?, 0xa6b4df?})
        /workspace/debug/cmd/viewcore/main.go:483 +0x1fb
github.com/spf13/cobra.(*Command).execute(0xed62e0, {0xeffd80, 0x0, 0x0})
        /gopath/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x843
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000ff208)
        /gopath/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
        /gopath/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
main.runRoot.func2()
        /workspace/debug/cmd/viewcore/main.go:361 +0x7c
main.capturePanic(0xb32820?)
        /workspace/debug/cmd/viewcore/main.go:376 +0x51
main.runRoot(0xed5760, {0xc00007e880?, 0x4?, 0xa6b4df?})
        /workspace/debug/cmd/viewcore/main.go:358 +0x672
github.com/spf13/cobra.(*Command).execute(0xed5760, {0xc000022120, 0x2, 0x2})
        /gopath/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x843
github.com/spf13/cobra.(*Command).ExecuteC(0xed5760)
        /gopath/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
        /gopath/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
main.main()
        /workspace/debug/cmd/viewcore/main.go:244 +0x132
```

```
Core "tmp/core.283046" was generated by "/gce-pd-csi-driver"
Entering interactive mode (type 'help' for commands)
(viewcore) histogram
Error while trying to run command "histogram": runtime error: invalid memory address or nil pointer dereference
Stack: goroutine 1 [running]:
runtime/debug.Stack()
        /usr/lib/google-golang/src/runtime/debug/stack.go:26 +0x5e
main.capturePanic.func1()
        /workspace/debug/cmd/viewcore/main.go:372 +0x3d
panic({0x9e8b20?, 0xecb700?})
        /usr/lib/google-golang/src/runtime/panic.go:799 +0x132
golang.org/x/debug/internal/gocore.(*Process).typeObject(0xc0002ca000, 0x300b8f0, 0xc0033a8300, {0xb348b0, 0xc0002be000}, 0xc00b28d280)
        /workspace/debug/internal/gocore/type.go:648 +0xedb
golang.org/x/debug/internal/gocore.(*Process).doTypeHeap.func2(0x0?)
        /workspace/debug/internal/gocore/type.go:539 +0x91
golang.org/x/debug/internal/gocore.(*Process).ForEachRoot(...)
        /workspace/debug/internal/gocore/object.go:191
golang.org/x/debug/internal/gocore.(*Process).doTypeHeap(0xc0002ca000)
        /workspace/debug/internal/gocore/type.go:532 +0x1f6
sync.(*Once).doSlow(0x564562?, 0xc00b28d560?)
        /usr/lib/google-golang/src/sync/once.go:78 +0xab
sync.(*Once).Do(...)
        /usr/lib/google-golang/src/sync/once.go:69
golang.org/x/debug/internal/gocore.(*Process).typeHeap(...)
        /workspace/debug/internal/gocore/type.go:403
golang.org/x/debug/internal/gocore.(*Process).Type(0xc0002ca000, 0xc000034000)
        /workspace/debug/internal/gocore/object.go:219 +0x4a
main.typeName(0xc0002ca000, 0xc000034000)
        /workspace/debug/cmd/viewcore/main.go:789 +0x9e
main.runHistogram.func1(0xc0002ca000?, 0xc000034000, 0x8?)
        /workspace/debug/cmd/viewcore/main.go:484 +0x3a
golang.org/x/debug/internal/gocore.(*Process).ForEachRootPtr.func1(0x0, 0xc00ac7f440?)
        /workspace/debug/internal/gocore/object.go:257 +0x3f
golang.org/x/debug/internal/gocore.walkRootTypePtrs(0xc0002ca000, 0xc007396480, {0xc00b28d718, 0x8, 0x8}, 0x0, 0xc00826cea0?, 0xc00b28d720)
        /workspace/debug/internal/gocore/root.go:163 +0x2ab
golang.org/x/debug/internal/gocore.(*Process).forEachRootPtr(...)
        /workspace/debug/internal/gocore/object.go:269
golang.org/x/debug/internal/gocore.(*Process).ForEachRootPtr(0xc00017e300?, 0xa6acf5?, 0x3?)
        /workspace/debug/internal/gocore/object.go:254 +0x4b
main.runHistogram(0xc00017e300?, {0xeffd80?, 0x4?, 0xa6b4df?})
        /workspace/debug/cmd/viewcore/main.go:483 +0x1fb
github.com/spf13/cobra.(*Command).execute(0xed62e0, {0xeffd80, 0x0, 0x0})
        /gopath/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x843
github.com/spf13/cobra.(*Command).ExecuteC(0xc000187208)
        /gopath/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
        /gopath/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
main.runRoot.func2()
        /workspace/debug/cmd/viewcore/main.go:361 +0x7c
main.capturePanic(0xb32820?)
        /workspace/debug/cmd/viewcore/main.go:376 +0x51
main.runRoot(0xed5760, {0xc00012a860?, 0x4?, 0xa6b4df?})
        /workspace/debug/cmd/viewcore/main.go:358 +0x672
github.com/spf13/cobra.(*Command).execute(0xed5760, {0xc0001300a0, 0x2, 0x2})
        /gopath/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x843
github.com/spf13/cobra.(*Command).ExecuteC(0xed5760)
        /gopath/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
        /gopath/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
main.main()
        /workspace/debug/cmd/viewcore/main.go:244 +0x132
```
